### PR TITLE
chore(bots): enabled mergeable bot

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,0 +1,8 @@
+version: 2
+mergeable:
+  - when: pull_request.*
+    validate:
+      - do: dependent
+        changed:
+          file: 'package.json'
+          files: ['package-lock.json', 'yarn.lock']


### PR DESCRIPTION
Mergeable bot can work with a variety of different rules. This configuration checks if `package.json` and `yarn.lock` files had been updated together.